### PR TITLE
Rejected membership balance upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ __pycache__/
 
 # Virtualenv
 /venv/
+/.venv/
+/myvenv/
 
 # Misc
 Socrates/config.py

--- a/general/views.py
+++ b/general/views.py
@@ -125,6 +125,10 @@ class UpgradeBalanceInstructionsView(TemplateView):
             associations = Association.objects.order_by("slug")
             context["user_associations"] = associations.filter(
                 usermembership__related_user=self.request.user
+            ).exclude(
+                # User wasn't verified and isn't pending (verification date is empty for pending users)
+                usermembership__is_verified=False,
+                usermembership__verified_on__isnull=False,
             )
             context["other_associations"] = associations.exclude(
                 id__in=context["user_associations"].values_list("id", flat=True)


### PR DESCRIPTION
Balance upgrade instructions for associations with rejected memberships shouldn't appear under "your associations".

<details>
<summary>Screenshots</summary>

![image](https://github.com/VSEScala/Scala-Dining/assets/34304046/e4ecbb22-19ed-4328-a6e1-5f4090f8e128)

![image](https://github.com/VSEScala/Scala-Dining/assets/34304046/1a2df1b8-05db-4baf-ad28-b7b395e4a65f)

</details>