### PR TITLE
Fix datetime-local input field

### DIFF
--- a/dining/forms.py
+++ b/dining/forms.py
@@ -25,6 +25,7 @@ from dining.models import (
 from general.forms import ConcurrenflictFormMixin
 from general.mail_control import construct_templated_mail
 from general.util import SelectWithDisabled
+from scaladining.fields import DateTimeControlField
 from userdetails.models import Association, User, UserMembership
 
 __all__ = [
@@ -219,6 +220,7 @@ class DiningInfoForm(ConcurrenflictFormMixin, ServeTimeCheckMixin, forms.ModelFo
     class Meta:
         model = DiningList
         fields = ["owners", "dish", "serve_time", "max_diners", "sign_up_deadline"]
+        field_classes = {"sign_up_deadline": DateTimeControlField}
         widgets = {
             "owners": ModelSelect2Multiple(
                 url="people_autocomplete", attrs={"data-minimum-input-length": "1"}
@@ -228,7 +230,6 @@ class DiningInfoForm(ConcurrenflictFormMixin, ServeTimeCheckMixin, forms.ModelFo
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["serve_time"].widget.input_type = "time"
-        self.fields["sign_up_deadline"].widget.input_type = "datetime-local"
         self.set_bounds(
             "serve_time", "min", settings.KITCHEN_USE_START_TIME.strftime("%H:%M")
         )

--- a/scaladining/fields.py
+++ b/scaladining/fields.py
@@ -1,0 +1,27 @@
+"""Custom form fields."""
+
+from django import forms
+
+
+class DateTimeControlInput(forms.DateTimeInput):
+    """See DateTimeControlField."""
+
+    input_type = "datetime-local"
+
+    def format_value(self, value):
+        # The value given seems to be naive. If it wasn't, we would need to
+        # make it naive first.
+        return value.strftime("%Y-%m-%dT%H:%M")
+
+
+class DateTimeControlField(forms.DateTimeField):
+    """Field for input type datetime-local.
+
+    The field requires a very specific format for the value attribute. This
+    subclass sets the formatted value and the input format correctly.
+
+    See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local
+    """
+
+    input_formats = ("%Y-%m-%dT%H:%M",)
+    widget = DateTimeControlInput


### PR DESCRIPTION
The [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) input field used for the sign up deadline did not use the correct format for the `value` attribute, which made it impossible to edit the sign up deadline. Also the currently set value was not correctly prefilled in the widget.