### PR TITLE
Fix thousand separator wrecking forms

### DIFF
--- a/assets/templates/accounts/snippet_member_edits.html
+++ b/assets/templates/accounts/snippet_member_edits.html
@@ -1,3 +1,4 @@
+{% load l10n %}
 {% load humanize %}
 <tr>
     <td>{{ entry.related_user.get_username }}</td>
@@ -15,7 +16,7 @@
     {# Verify button #}
     <td>
         {% if not entry.is_verified %}
-            <button type="submit" name="validate-yes-{{ entry.id }}" class="btn btn-block btn-outline-success">
+            <button type="submit" name="validate-yes-{{ entry.id|unlocalize }}" class="btn btn-block btn-outline-success">
                 {# Only icon because the button is not wide enough for text. #}
                 <i class="fa fa-check-circle"></i>
             </button>
@@ -24,7 +25,7 @@
     {# Deny button #}
     <td>
         {% if entry.is_verified or not entry.verified_on %}
-            <button type="submit" name="validate-no-{{ entry.id }}" class="btn btn-block btn-outline-danger">
+            <button type="submit" name="validate-no-{{ entry.id|unlocalize }}" class="btn btn-block btn-outline-danger">
                 <i class="fa fa-times-circle"></i>
             </button>
         {% endif %}

--- a/assets/templates/dining_lists/dining_slot_diners.html
+++ b/assets/templates/dining_lists/dining_slot_diners.html
@@ -1,6 +1,6 @@
 {% extends 'dining_lists/dining_slot.html' %}
 
-{% load dining_tags %}
+{% load dining_tags l10n %}
 
 {% block tab_list %}active{% endblock %}
 
@@ -44,7 +44,7 @@
                                   action="{% url 'slot_list' day=date.day month=date.month year=date.year identifier=dining_list.association.slug %}"
                                   class="stats-form d-inline-block mt-1 mt-md-0">
                                 {% csrf_token %}
-                                <input type="hidden" name="entry_id" value="{{ entry.pk }}">
+                                <input type="hidden" name="entry_id" value="{{ entry.pk|unlocalize }}">
                                 <input type="hidden" name="shopped_val" value="{% if entry.has_shopped %}1{% endif %}">
                                 <input type="hidden" name="cooked_val" value="{% if entry.has_cooked %}1{% endif %}">
                                 <input type="hidden" name="cleaned_val" value="{% if entry.has_cleaned %}1{% endif %}">

--- a/assets/templates/dining_lists/dining_slot_info.html
+++ b/assets/templates/dining_lists/dining_slot_info.html
@@ -1,4 +1,5 @@
 {% extends 'dining_lists/dining_slot.html' %}
+{% load l10n %}
 {% load dining_tags credit_tags humanize %}
 
 {% block tab_info %}active{% endblock %}
@@ -119,7 +120,7 @@
                     {% url 'entry_add' day=date.day month=date.month year=date.year identifier=dining_list.association.slug as url %}
                     <form method="post" action="{{ url }}?next={{ request.path_info }}">
                         {% csrf_token %}
-                        <input type="hidden" name="user" value="{{ user.pk }}">
+                        <input type="hidden" name="user" value="{{ user.pk|unlocalize }}">
                         <button type="submit" class="btn btn-block btn-primary">Sign up</button>
                     </form>
                 {% endif %}

--- a/assets/templates/dining_lists/dining_slot_info_alter.html
+++ b/assets/templates/dining_lists/dining_slot_info_alter.html
@@ -1,4 +1,5 @@
 {% extends 'dining_lists/dining_slot.html' %}
+{% load l10n %}
 
 {% block details %}
     <p><a href="{{ dining_list.get_absolute_url }}">← Back to dining list</a></p>
@@ -22,7 +23,7 @@
         document.getElementById('infoForm').addEventListener('submit', function (event) {
             let selectedOptions = document.getElementById('id_info-owners').selectedOptions;
             for (let i = 0; i < selectedOptions.length; i++) {
-                if (selectedOptions[i].value === '{{ user.pk }}') {
+                if (selectedOptions[i].value === '{{ user.pk|unlocalize }}') {
                     // Current user is owner
                     return;
                 }

--- a/assets/templates/dining_lists/snippet_diningslot.html
+++ b/assets/templates/dining_lists/snippet_diningslot.html
@@ -1,3 +1,4 @@
+{% load l10n %}
 {% load dining_tags %}
 
 <div class="col-12 mx-0 my-2 btn d-inline-flex text-left
@@ -34,7 +35,7 @@
             {% url 'slot_details' day=date.day month=date.month year=date.year identifier=slot.association.slug as next%}
             <form method="post" action="{{ url }}?next={{ next }}" class="btn-block col-2 slot-signup d-none d-md-inline-flex">
                 {% csrf_token %}
-                <input type="hidden" name="user" value="{{ user.pk }}">
+                <input type="hidden" name="user" value="{{ user.pk|unlocalize }}">
                 <button type="submit" class="btn-block btn btn-primary slot-signup"></button>
             </form>
         {% else %}

--- a/assets/templates/socialaccount/connections.html
+++ b/assets/templates/socialaccount/connections.html
@@ -1,4 +1,5 @@
 {% extends "account/settings/settings_linked_accounts.html" %}
+{% load l10n %}
 
 {% load socialaccount %}
 
@@ -19,9 +20,9 @@
                 {% for base_account in form.accounts %}
                     {% with base_account.get_provider_account as account %}
                         <div class="custom-control custom-radio">
-                            <input id="id_account_{{ base_account.id }}" type="radio" name="account"
-                                   value="{{ base_account.id }}" class="custom-control-input">
-                            <label for="id_account_{{ base_account.id }}" class="custom-control-label">
+                            <input id="id_account_{{ base_account.id|unlocalize }}" type="radio" name="account"
+                                   value="{{ base_account.id|unlocalize }}" class="custom-control-input">
+                            <label for="id_account_{{ base_account.id|unlocalize }}" class="custom-control-label">
                                 {{ account.get_brand.name }}: {{ account }}
                             </label>
                         </div>

--- a/scaladining/settings.py
+++ b/scaladining/settings.py
@@ -137,9 +137,12 @@ LANGUAGE_CODE = "en-us"
 FORMAT_MODULE_PATH = "scaladining.formats"
 
 USE_I18N = False
-USE_THOUSAND_SEPARATOR = True
-# USE_TZ is True by default from Django 5.0
-USE_TZ = True
+
+# This setting (USE_THOUSAND_SEPARATOR) is a bit dangerous, because it will apply to
+# integers in hidden inputs. So a hidden primary key in a form might get value `46.235`
+# while it should be `46235`. Use the `unlocalize` template filter to prevent this.
+#
+# USE_THOUSAND_SEPARATOR = True
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",


### PR DESCRIPTION
This bug appeared because Django removed the setting `USE_L10N` in version 5.0. We had it set to false but now this setting can't be disabled anymore. We also had `USE_THOUSAND_SEPARATOR` set to true. Now hidden primary key values in forms are formatted as `12.345` instead of `12345` breaking the form.

I disabled `USE_THOUSAND_SEPARATOR` and I changed the templates to use `unlocalize` for these numbers (as a precaution).