### PR TITLE
Added filter for association only in admin panel

### DIFF
--- a/dining/admin.py
+++ b/dining/admin.py
@@ -42,8 +42,14 @@ class DiningEntryAdmin(admin.ModelAdmin):
 
 @admin.register(DiningList)
 class DiningListAdmin(admin.ModelAdmin):
-    list_display = ("date", "association", "dish", "is_adjustable")
-    list_filter = ("association", "date")
+    list_display = (
+        "date",
+        "association",
+        "dish",
+        "is_adjustable",
+        "limit_signups_to_association_only",
+    )
+    list_filter = ("association", "date", "limit_signups_to_association_only")
     readonly_fields = ("diners",)
     filter_horizontal = ("owners",)
 

--- a/dining/models.py
+++ b/dining/models.py
@@ -74,7 +74,7 @@ class DiningList(models.Model):
     )
     # Todo: implement limit in the views.
     limit_signups_to_association_only = models.BooleanField(
-        "Association only",
+        "association only",
         default=False,
         help_text="Whether only members of the given association can sign up.",
     )

--- a/dining/models.py
+++ b/dining/models.py
@@ -74,6 +74,7 @@ class DiningList(models.Model):
     )
     # Todo: implement limit in the views.
     limit_signups_to_association_only = models.BooleanField(
+        "Association only",
         default=False,
         help_text="Whether only members of the given association can sign up.",
     )


### PR DESCRIPTION
#295 
I also renamed the title of the field to be "Association only" instead of "Limit signups to association only" to keep a more concise overview. Since there is a description field added anyways, this should be enough information for the user. 